### PR TITLE
Change JUMP syntax, limit functionality to prepare for dev4 IF, LOOP takes in label instead of line number

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ S# (Simple Stack Script) is a lightweight, stack-based programming language desi
 
 ## Important: We are now an officially published Python package!!! 
 
+> [!CAUTION]
+> You are currently on the experimental branch of S#. We are currently testing new syntax for the language and you might come accross various issues and bugs. We recommend you switch to the main branch, or for bleeding updates, check for any feature/* brances!
+
 ## 🚀 Features
 
 -   **Stack-Based Execution:** Operates on a Last-In-First-Out (LIFO) stack.

--- a/ssharp_package/interpreter.py
+++ b/ssharp_package/interpreter.py
@@ -29,11 +29,11 @@ for line in program_lines:                          # Go through each line of th
     opcode = line_parts[0]                          # Define the opcode as the first part of the line
 
     if opcode.endswith(":"):
-        label_tracker[opcode[:-1]] = token_counter                           # Store the label and its token number
+        label_tracker[opcode[:-1]] = token_counter  # Store the label and its token number
         continue
 
-    program.append(opcode)                                                   # Add the opcode to the program, increment the token counter
-    token_counter += 1
+    program.append(opcode)                          # Add the opcode to the program
+    token_counter += 1                              # Increment the token counter
 
     ##################################################
     #            Handle Paremeter Opcodes            #
@@ -69,26 +69,27 @@ for line in program_lines:                          # Go through each line of th
 
     elif opcode == "LOOP":                                                   # ---- If the opcode is LOOP ----
         try:
-            line_number = int(line_parts[1])
-            repeat_count = int(line_parts[2])
-            program.append(line_number)
-            program.append(repeat_count)
-            token_counter += 2
+            label = line_parts[1]                                            # Get the label
+            if label not in label_tracker:
+                raise ValueError(f"Undefined label '{label}' in {opcode}")   # If the label is not defined, raise an error
+            repeat_count = int(line_parts[2])                                # Get the repeat count
+            program.append(label)                                            # Add the label to the program         <-| Increment token counter by 2
+            program.append(repeat_count)                                     # Add the repeat count to the program  <-| because we added 2 tokens
+            token_counter += 2                                               # Increment the token counter by 2 ------| to the program counter!
         except (IndexError, ValueError):
-            raise ValueError(f"Invalid LOOP format: {line}")
+            raise ValueError(f"Invalid LOOP format: {line}")                 # If the format is invalid, raise an error
 
-    elif opcode == "WAIT":
-        # Expects a number
+    elif opcode == "WAIT":                                                   # ---- If the opcode is WAIT ----
         try:
-            number = int(line_parts[1])
-            program.append(number)
-            token_counter += 1
+            number = int(line_parts[1])                                      # Parse the number
+            program.append(number)                                           # Add the number to the program
+            token_counter += 1                                               # Increment the token counter
         except (IndexError, ValueError):
-            raise ValueError(f"Invalid number in WAIT: {line}")
+            raise ValueError(f"Invalid number in WAIT: {line}")              # If the number is not valid, raise an error
 
-###########################
-#     Interpretation      #
-###########################
+##################################################
+#                 Interpretation                 #
+##################################################
 
 class Stack:
     def __init__(self, size):

--- a/ssharp_package/interpreter.py
+++ b/ssharp_package/interpreter.py
@@ -59,16 +59,15 @@ for line in program_lines:                          # Go through each line of th
         else:
             raise ValueError(f"Invalid string literal in PRINT: {line}")     # Gracefully raise a program error
 
-    elif opcode in ["JUMP", "JUMP.IF.0", "JUMP.IF.POS"]:
-        # Expects a label
-        label = line_parts[1]
-        if label not in label_tracker:
-            raise ValueError(f"Undefined label '{label}' in {opcode}")
-        program.append(label)
-        token_counter += 1
+    elif opcode == "GOTO":                                                   # ---- If the opcode is GOTO ----
 
-    elif opcode == "LOOP":
-        # Expects a line number and a repeat count
+        label = line_parts[1]                                                # Get the label
+        if label not in label_tracker:
+            raise ValueError(f"Undefined label '{label}' in {opcode}")       # If the label is not defined, raise an error
+        program.append(label)                                                # Add the label to the program
+        token_counter += 1                                                   # Increment the token counter
+
+    elif opcode == "LOOP":                                                   # ---- If the opcode is LOOP ----
         try:
             line_number = int(line_parts[1])
             repeat_count = int(line_parts[2])

--- a/ssharp_package/interpreter.py
+++ b/ssharp_package/interpreter.py
@@ -1,62 +1,63 @@
+# Import libraries
 import sys
 from time import sleep
 
-# read filepath
+# Take the filepath from the argument when running this script
 program_filepath = sys.argv[1]
 
-###########################
-#      Tokenization       #
-###########################
+##################################################
+#                  Tokenization                  #
+##################################################
 
-# read file line-by-line
+# Read the file line by line
 program_lines = []
 with open(program_filepath, 'r') as program_file:
     program_lines = [line.strip() for line in program_file.readlines()]
 
-program = []
-token_counter = 0
-label_tracker = {}
+program = []                                        # Stores program tokens
+token_counter = 0                                   # Stores the number of tokens
+label_tracker = {}                                  # Stores the token place of labels
 
-for line in program_lines:
+for line in program_lines:                          # Go through each line of the program
 
-    # Remove comments
-    line = line.split("#", 1)[0].strip()
+    line = line.split("#", 1)[0].strip()            # Remove the comments from every line
     
-    if not line:
-        continue  # Skip empty lines
-
-    line_parts = line.split(" ")
-    opcode = line_parts[0]
-
-    # Check if opcode is a label
-    if opcode.endswith(":"):
-        label_tracker[opcode[:-1]] = token_counter
+    if not line:                                    # Remove all empty lines
         continue
 
-    # store opcode token
-    program.append(opcode)
+    line_parts = line.split(" ")                    # Split the line by spaces
+    opcode = line_parts[0]                          # Define the opcode as the first part of the line
+
+    if opcode.endswith(":"):
+        label_tracker[opcode[:-1]] = token_counter                           # Store the label and its token number
+        continue
+
+    program.append(opcode)                                                   # Add the opcode to the program, increment the token counter
     token_counter += 1
 
-    # Handle opcodes
-    if opcode == "PUSH":
-        # Expects a number
-        try:
-            number = int(line_parts[1])
-            program.append(number)
-            token_counter += 1
-        except (IndexError, ValueError):
-            raise ValueError(f"Invalid number in PUSH: {line}")
+    ##################################################
+    #            Handle Paremeter Opcodes            #
+    ##################################################
 
-    elif opcode == "PRINT":
-        # Expects a string literal
-        raw_string = ' '.join(line_parts[1:]).strip()
+    if opcode == "PUSH":                                                     # ---- If the opcode is PUSH ----
+        try:
+            number = int(line_parts[1])                                      # Parse the number
+            program.append(number)                                           # Add the number to the program
+            token_counter += 1                                               # Increment the token counter
+
+        except (IndexError, ValueError):                                     # If the number is not valid
+            raise ValueError(f"Invalid number in PUSH: {line}")              # Gracefully raise a program error
+
+    elif opcode == "PRINT":                                                  # ---- If the opcode is PRINT ----
+
+        raw_string = ' '.join(line_parts[1:]).strip()                        # Join the rest of the line as a string
         if (raw_string.startswith('"') and raw_string.endswith('"')) or \
-           (raw_string.startswith("'") and raw_string.endswith("'")):
-            string_literal = raw_string[1:-1]  # Remove quotes
-            program.append(string_literal)
-            token_counter += 1
+           (raw_string.startswith("'") and raw_string.endswith("'")):        # If the string is enclosed in quotes (single or double)
+            string_literal = raw_string[1:-1]                                # Remove the quotes
+            program.append(string_literal)                                   # Add the string to the program
+            token_counter += 1                                               # Increment the token counter
         else:
-            raise ValueError(f"Invalid string literal in PRINT: {line}")
+            raise ValueError(f"Invalid string literal in PRINT: {line}")     # Gracefully raise a program error
 
     elif opcode in ["JUMP", "JUMP.IF.0", "JUMP.IF.POS"]:
         # Expects a label

--- a/ssharp_package/interpreter.py
+++ b/ssharp_package/interpreter.py
@@ -86,34 +86,40 @@ for line in program_lines:                          # Go through each line of th
             token_counter += 1                                               # Increment the token counter
         except (IndexError, ValueError):
             raise ValueError(f"Invalid number in WAIT: {line}")              # If the number is not valid, raise an error
+    
+    # TODO: IF OPCODE, SEE BELOW
+    # 
+    # The IF opcode has three arguments: IF [<|>|=] <number> <secondary_opcode> ...
+    # This allows conditional logic where if the top of the stack is greater than, less than,
+    # or equal to, a different opcode can start.
 
 ##################################################
 #                 Interpretation                 #
 ##################################################
 
-class Stack:
+class Stack:                                                    # Start the stack memory
     def __init__(self, size):
-        self.buf = [0 for _ in range(size)]
-        self.sp = -1
+        self.array = [0 for _ in range(size)]                   # Initialize the stack with zeros
+        self.sp = -1                                            # Initialize the pointer right before the stack
         self.size = size
 
-    def push(self, number):
-        if self.sp >= self.size - 1:
-            raise IndexError("Stack Overflow")  
-        self.sp += 1
-        self.buf[self.sp] = number
+    def push(self, number):                                     # Stack push function
+        if self.sp >= self.size - 1:                            # If the pointer is pointing beyond stack memory
+            raise IndexError("Stack Overflow")                  # Gracefully raise stack overflow error
+        self.sp += 1                                            # Move pointer to front of stack
+        self.array[self.sp] = number                            # Assign stack value to number
 
-    def pop(self):
-        if self.sp < 0:
-            raise IndexError("Stack Underflow")
-        number = self.buf[self.sp]
-        self.sp -= 1
-        return number
+    def pop(self):                                              # Stack pop functionality
+        if self.sp < 0:                                         # If the pointer is pointing below stack memory
+            raise IndexError("Stack Underflow")                 # Gracefully raise stack underflow error
+        number = self.array[self.sp]                            # Get top value of stack
+        self.sp -= 1                                            # Move pointer to the next back of the stack
+        return number                                           # Return number for optional further processing
     
-    def top(self):
-        if self.sp < 0:
-            raise IndexError("Stack is Empty")
-        return self.buf[self.sp]
+    def top(self):                                              # Stack top functionality
+        if self.sp < 0:                                         # If the pointer is pointing below stack memory
+            raise IndexError("Stack is Empty")                  # Gracefully raise stack empty error
+        return self.array[self.sp]                              # Return top of stack for processing
 
 pc = 0
 stack = Stack(256)

--- a/ssharp_package/interpreter.py
+++ b/ssharp_package/interpreter.py
@@ -121,57 +121,56 @@ class Stack:                                                    # Start the stac
             raise IndexError("Stack is Empty")                  # Gracefully raise stack empty error
         return self.array[self.sp]                              # Return top of stack for processing
 
-pc = 0
-stack = Stack(256)
-loop_tracker = {}
+pc = 0                                          # Instantiate the program counter
+stack = Stack(256)                              # Instantiate the stack memory
+loop_tracker = {}                               # Instantiate loop tracking
 
-while pc < len(program):
+while pc < len(program):                        # Start the program loop
 
-    opcode = program[pc]
-    pc += 1
+    opcode = program[pc]                        # Load first opcode for processing
+    pc += 1                                     # Increase program counter
 
-    if opcode == "PUSH":
+    if opcode == "PUSH":                        # Adds a number to the stack memory
         number = program[pc]
         pc += 1
         stack.push(number)
 
-    elif opcode == "POP":
+    elif opcode == "POP":                       # Removes a number from stack memory
         stack.pop()
 
-    elif opcode == "ADD":
-        a = stack.pop()
+    elif opcode == "ADD":                       # Adds two numbers from stack memory
+        a = stack.pop()                         # It removes the top two numbers from stack to add, then pushes
         b = stack.pop()
         stack.push(a + b)
 
-    elif opcode == "SUB":
-        a = stack.pop()
+    elif opcode == "SUB":                       # Subtracts two numbers from stack memory
+        a = stack.pop()                         # It removes the top two numbers from stack to subtract, then pushes
         b = stack.pop()
         stack.push(b - a)
 
-    elif opcode == "MUL":
-        a = stack.pop()
+    elif opcode == "MUL":                       # Multiplies two numbers from stack memory
+        a = stack.pop()                         # Same thing as add and subtract...
         b = stack.pop()
         stack.push(a * b)
 
-    elif opcode == "DIV":  
-        a = stack.pop()
+    elif opcode == "DIV":                       # Same thing as add, subtract, and multipy...
+        a = stack.pop()                         # With graceful divide by zero error
         b = stack.pop()
         if a == 0:
             raise ZeroDivisionError("Division by zero")
         stack.push(b // a)
 
-    elif opcode == "PRINT":
+    elif opcode == "PRINT":                     # Logic to print to screen
         string_literal = program[pc]
         pc += 1
         print(string_literal)
 
-    elif opcode == "READ":
+    elif opcode == "READ":                      # Logic to read user input
         try:
             value = int(input())  
             stack.push(value)
         except ValueError:
-            print("Error: Invalid input. Must be an integer.", file=sys.stderr)
-            exit(1)
+            raise ValueError("Invalid integer input")
 
     elif opcode == "JUMP":
         label = program[pc]

--- a/ssharp_package/interpreter.py
+++ b/ssharp_package/interpreter.py
@@ -172,84 +172,88 @@ while pc < len(program):                        # Start the program loop
         except ValueError:
             raise ValueError("Invalid integer input")
 
-    elif opcode == "JUMP":
+    elif opcode == "GOTO":                      # Logic to forward pointer counter to label
         label = program[pc]
         pc = label_tracker[label]
 
-    elif opcode == "JUMP.IF.0":
-        number = stack.top()
-        if number == 0:
-            pc = label_tracker[program[pc]]
-        else:
-            pc += 1
+    # elif opcode == "JUMP":
+    #     label = program[pc]
+    #     pc = label_tracker[label]
 
-    elif opcode == "JUMP.IF.POS":
-        number = stack.top()
-        if number > 0:
-            pc = label_tracker[program[pc]]
-        else:
-            pc += 1
+    # elif opcode == "JUMP.IF.0":
+    #     number = stack.top()
+    #     if number == 0:
+    #         pc = label_tracker[program[pc]]
+    #     else:
+    #         pc += 1
 
-    elif opcode == "LOOP":
-        line_number = int(program[pc])  # Jump line
+    # elif opcode == "JUMP.IF.POS":
+    #     number = stack.top()
+    #     if number > 0:
+    #         pc = label_tracker[program[pc]]
+    #     else:
+    #         pc += 1
+
+    elif opcode == "LOOP":                      # Logic to loop
+        label = program[pc]                     # Get the label from the program
         pc += 1
-        repeat_count = int(program[pc])  # Times to repeat
+        repeat_count = int(program[pc])         # Get the iteration amount from the program
         pc += 1
 
-        loop_key = f"LOOP-{line_number}"
+        loop_key = f"LOOP-{label}"              # Initialize the loop key for the tracker
 
-        if loop_key not in loop_tracker:
-            loop_tracker[loop_key] = repeat_count  # Initialize repeat count
+        if loop_key not in loop_tracker:        # If not already in tracker, add the key to the tracker
+            loop_tracker[loop_key] = repeat_count
 
-        if loop_tracker[loop_key] > 0:
-            loop_tracker[loop_key] -= 1
-            pc = line_number  # Jump to specified line number
+        if loop_tracker[loop_key] > 0:          # If the value of the iteration amount is higher than zero
+            loop_tracker[loop_key] -= 1         # Decrement the iteration amount by 1
+            pc = label_tracker[label]           # Forward pointer counter to the label
         else:
-            del loop_tracker[loop_key]
+            del loop_tracker[loop_key]          # If the value of the iteration amount is zero or less, delete the loop key
 
-    elif opcode == "HALT":
+    elif opcode == "HALT":                      # Break the program loop for a HALT opcode
         break
 
-    elif opcode == "DUP":
+    elif opcode == "DUP":                       # Duplicate the top value
         stack.push(stack.top())
 
-    elif opcode == "SWAP":
+    elif opcode == "SWAP":                      # Swap the top two values
         a = stack.pop()
         b = stack.pop()
         stack.push(a)
         stack.push(b)
 
-    elif opcode == "OVER":
-        a = stack.pop()
-        b = stack.pop()
-        stack.push(b)
-        stack.push(a)
-        stack.push(b)
+    elif opcode == "OVER":                      # Sandwich the top value between the second top value
+        a = stack.pop()                         # EXAMPLE BELOW
+        b = stack.pop()                         #
+        stack.push(b)                           # TOP to BOTTOM     |     
+        stack.push(a)                           # 5, 3, 2, 7        |
+        stack.push(b)                           # 3, 5, 3, 2, 7    \|/
 
-    elif opcode == "ROT":
-        a = stack.pop()
-        b = stack.pop()
-        c = stack.pop()
-        stack.push(b)
-        stack.push(a)
-        stack.push(c)
+    elif opcode == "ROT":                       # Sandwich the top value between second top and third top value
+        a = stack.pop()                         # EXAMPLE BELOW
+        b = stack.pop()                         #
+        c = stack.pop()                         # TOP to BOTTOM     |
+        stack.push(b)                           # 5, 3, 2, 7        |
+        stack.push(a)                           # 3, 5, 2, 7       \|/
+        stack.push(c)                           #
 
-    elif opcode == "NIP":
+    elif opcode == "NIP":                       # Remove the second top value
         a = stack.pop()
         stack.pop()
         stack.push(a)
 
-    elif opcode == "TUCK":
-        a = stack.pop()
-        b = stack.pop()
-        stack.push(a)
-        stack.push(b)
-        stack.push(a)
+    elif opcode == "TUCK":                      # Sandwich the second top value between the top value
+        a = stack.pop()                         # EXAMPLE BELOW
+        b = stack.pop()                         #
+        stack.push(a)                           # TOP to BOTTOM
+        stack.push(b)                           # 5, 3, 2, 7
+        stack.push(a)                           # 5, 3, 5, 2, 7
 
-    elif opcode == "PRINT.TOP":
-        print(stack.top())
+    elif opcode == "PRINT.TOP":                 # Prints top value in stack
+        print(stack.top())                      # TODO: Make it so you can do this in the PRINT opcode
 
-    elif opcode == "WAIT":
+    elif opcode == "WAIT":                      # Sleep logic
         number = program[pc]
         pc += 1
         sleep(number)


### PR DESCRIPTION
## Major Changes/Minor Changes

We changed the JUMP syntax to be GOTO. This is used like this: `GOTO <label>` and will have more functionality when we update to dev4 including the IF statement. The JUMP.EQ.0 and JUMP.IF.POS have been commented out/removed because the IF statement will be replacing them.

We also changed LOOP to take in a label instead of a line number. This is used like this: `LOOP <label> <iterations>` and makes S# easier to read and makes more intuitive sense.

For all other contributors and developers, an extensive amount of comments have been added. Some people say it's to much, but it helped me focus.

_This will make it so previous versions of S# will not be able to work since syntax is changing!_